### PR TITLE
Showing error message for invalid topic selection

### DIFF
--- a/static/js/client.js
+++ b/static/js/client.js
@@ -51,6 +51,10 @@ $(document).ready(function() {
     $('select').formSelect();
     $('.modal').modal();
 
+    // MaterializeCSS hides the native select, which causes the data-error to not show up
+    // This is a little bit of a "hacky" way to ensure the user selects a topic
+    $('select[required]').css({display: "block", top: "0%", padding: 0, opacity: 0, position: 'absolute'});
+
     $(document).on("click", ".remove-button", function(event) {
         if (!$(this).hasClass("confirming")) {
             $(".confirming").each(function() {

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -61,7 +61,7 @@
     <label for="user_id">Andrew ID</label>
   </div>
   <div class="input-field inline col l4 m4 s12">
-    <select novalidate id="topic" name="topic_id">
+    <select id="topic" class="topic" name="topic_id" required>
         <option value="" disabled selected hidden>Choose a topic</option>
       <%_ topics.forEach(function(topic) { _%>
         <option value="<%= topic.id %>"><%= topic.name %></option>


### PR DESCRIPTION
Forgetting to select a topic would cause the entire page to refresh, forcing a student to re-enter each of the fields. This is a little of a "hacky" solution, but it shows the error message when a topic isn't selected
![image](https://user-images.githubusercontent.com/43687061/105412702-ac8ff800-5bfa-11eb-96b8-a89ad84bbf8c.png)